### PR TITLE
Sample a uniformly random point in point_around

### DIFF
--- a/src/poisson_disc_distribution.hpp
+++ b/src/poisson_disc_distribution.hpp
@@ -94,7 +94,7 @@ poisson_disc_distribution(config conf, T&& random, T2&& in_area, T3&& output)
     };
 
     auto point_around = [&conf, &random](point p) {
-        auto radius = random(conf.min_distance) + conf.min_distance;
+        auto radius = conf.min_distance * std::sqrt(random(3) + 1);
         auto angle = random(2 * M_PI);
 
         p.x += std::cos(angle) * radius;


### PR DESCRIPTION
The straightforward approach of using `random(conf.min_distance) + conf.min_distance` to sample from the annulus around the processed point unfortunately results in a distribution biased towards the smaller radius.

These two animations give a good illustration of the difference between the techniques: [Annulus Sampling I](https://bl.ocks.org/mbostock/31bd072e50eaf550d79e) (the "naive" approach) and [Annulus Sampling II](https://bl.ocks.org/mbostock/d8b1e0a25467e6034bb9) (the proposed change).

By using `conf.min_distance * std::sqrt(random(3) + 1)` we can generate points uniformly inside the annulus. Note that this is a simplification of `std::sqrt(random(3 * conf.min_distance * conf.min_distance) + conf.min_distance * conf.min_distance)`, which could also be written as:
```cpp
auto min_dist_squared = conf.min_distance * conf.min_distance;
auto max_dist_squared = 4 * conf.min_distance * conf.min_distance;
auto radius = std::sqrt(random(max_dist_squared - min_dist_squared) + min_dist_squared);
```